### PR TITLE
[WIP] Show skipped tests as ignored in team city

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
   "extends": "eslint:recommended",
   "rules": {
     "quotes": ["warn", "single"],
-    "indent": ["warn", 4]
+    "indent": ["warn", 4, { "SwitchCase": 1 } ]
   },
   "env": {
     "node": true

--- a/src/cucumber-teamcity-formatter.js
+++ b/src/cucumber-teamcity-formatter.js
@@ -54,21 +54,29 @@ export default class TeamCityFormatter extends Formatter {
             testCase: { result: { status, duration } }
         } = this.eventDataCollector.getTestCaseData(sourceLocation);
 
-        if (status === Status.AMBIGUOUS || status === Status.FAILED) {
-            const details = formatterHelpers.formatIssue({
-                colorFns: this.colorFns,
-                gherkinDocument,
-                number: 1,
-                pickle,
-                snippetBuilder: this.snippetBuilder,
-                testCase
-            });
+        switch (status) {
+            case Status.AMBIGUOUS:
+            case Status.FAILED: {
+                const details = formatterHelpers.formatIssue({
+                    colorFns: this.colorFns,
+                    gherkinDocument,
+                    number: 1,
+                    pickle,
+                    snippetBuilder: this.snippetBuilder,
+                    testCase
+                });
 
-            this.log(
-                `##teamcity[testFailed name='${this.escape(pickle.name)}' message='${this.escape(
-                    `${pickle.name} FAILED`
-                )}' details='${this.escape(details)}']\n`
-            );
+                this.log(
+                    `##teamcity[testFailed name='${this.escape(pickle.name)}' message='${this.escape(
+                        `${pickle.name} FAILED`
+                    )}' details='${this.escape(details)}']\n`
+                );
+                break;
+            }
+
+            case Status.SKIPPED:
+                this.log(`##teamcity[testIgnored name='${this.escape(pickle.name)}']\n`);
+                break;
         }
 
         this.log(`##teamcity[testFinished name='${this.escape(pickle.name)}' duration='${duration}']\n`);

--- a/src/cucumber-teamcity-formatter.js
+++ b/src/cucumber-teamcity-formatter.js
@@ -57,31 +57,39 @@ export default class TeamCityFormatter extends Formatter {
         switch (status) {
             case Status.AMBIGUOUS:
             case Status.FAILED: {
-                const details = formatterHelpers.formatIssue({
-                    colorFns: this.colorFns,
-                    gherkinDocument,
-                    number: 1,
-                    pickle,
-                    snippetBuilder: this.snippetBuilder,
-                    testCase
-                });
-
-                this.log(
-                    `##teamcity[testFailed name='${this.escape(pickle.name)}' message='${this.escape(
-                        `${pickle.name} FAILED`
-                    )}' details='${this.escape(details)}']\n`
-                );
+                this.logTestFailed(gherkinDocument, pickle, testCase)
                 break;
             }
 
             case Status.SKIPPED:
-                this.log(`##teamcity[testIgnored name='${this.escape(pickle.name)}']\n`);
+                this.logTestSkipped(pickle)
                 break;
         }
 
-        this.log(`##teamcity[testFinished name='${this.escape(pickle.name)}' duration='${duration}']\n`);
+        this.logTestFinished(pickle, duration);
 
         this.logTestSuiteFinishedIfLastTestCase({ sourceLocation, gherkinDocument });
+    }
+
+    logTestFailed(gherkinDocument, pickle, testCase) {
+        const details = formatterHelpers.formatIssue({
+            colorFns: this.colorFns,
+            gherkinDocument,
+            number: 1,
+            pickle,
+            snippetBuilder: this.snippetBuilder,
+            testCase
+        });
+
+        this.log(`##teamcity[testFailed name='${this.escape(pickle.name)}' message='${this.escape(`${pickle.name} FAILED`)}' details='${this.escape(details)}']\n`);
+    }
+
+    logTestSkipped(pickle) {
+        this.log(`##teamcity[testIgnored name='${this.escape(pickle.name)}']\n`);
+    }
+
+    logTestFinished(pickle, duration) {
+        this.log(`##teamcity[testFinished name='${this.escape(pickle.name)}' duration='${duration}']\n`);
     }
 
     escape(text) {


### PR DESCRIPTION
This is the PR for #2.

Whilst the tests pass, I'm not 100% this code works - when I added it to one of our projects here, scenarios which are skipped are showing as passed in team city. 

When I logged out the scenario status they are coming through as `passed` instead of `skipped`.  I'm not sure if the problem is:

1. Something wrong in my assumptions for this code.
2. Something wrong in the wiring in our solution (we have protractor and protractor-cucumber-framework in the mix).
3. Something wrong in cucumber.

Feel free to merge, but I'd like to keep this as WIP until I've had a change to investigate further.  Unfortunately I don't when that will be as I need to get on and ship some features to my customer.