### PR TITLE
chore: explicitly use npm install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
 before_install:
   - npm install -g greenkeeper-lockfile
 
+install:
+  - npm install
+
 before_script:
   - greenkeeper-lockfile-update
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Required for greenkeeper-lockfile.